### PR TITLE
refactor : 전체 알림 조회 , 펀딩 알림 조회 수정

### DIFF
--- a/src/main/java/efub/gift_u/domain/funding/dto/FundingResponseDetailDto.java
+++ b/src/main/java/efub/gift_u/domain/funding/dto/FundingResponseDetailDto.java
@@ -6,8 +6,7 @@ import efub.gift_u.domain.funding.domain.FundingStatus;
 import efub.gift_u.domain.gift.dto.GiftResponseDto;
 import efub.gift_u.domain.participation.dto.ParticipationResponseDto;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -15,8 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FundingResponseDetailDto {
 
     private Long fundingId;
@@ -26,13 +24,33 @@ public class FundingResponseDetailDto {
     private LocalDate fundingEndDate;
     private FundingStatus status;
     private LocalDateTime createdAt;
-    private Boolean visibility;
+    private boolean visibility;
     private Long password;
     private Long nowMoney;
     private String fundingImageUrl;
     private List<ParticipationResponseDto> contributers ;
     private boolean isExistedReview; // 선물 후기 존재 여부
     private List<GiftResponseDto> giftList; // 해당 펀딩의 선물 목록
+
+    public  FundingResponseDetailDto(Long fundingId , Long userId , String fundingTitle , String fundingContent,
+                                     LocalDate fundingEndDate , FundingStatus status , LocalDateTime createdAt ,
+                                     boolean visibility , Long password , Long nowMoney , String  fundingImageUrl ,
+                                     List<ParticipationResponseDto> contributers , boolean isExistedReview, List<GiftResponseDto> giftList){
+        this.fundingId = fundingId;
+        this.userId = userId;
+        this.fundingTitle = fundingTitle;
+        this.fundingContent = fundingContent;
+        this.fundingEndDate = fundingEndDate;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.visibility = visibility;
+        this.password = password;
+        this.nowMoney = nowMoney;
+        this.fundingImageUrl = fundingImageUrl;
+        this.contributers = contributers;
+        this.isExistedReview = isExistedReview;
+        this.giftList = giftList;
+    }
 
     public static FundingResponseDetailDto from(Funding funding, List<ParticipationResponseDto> participationDetail ,
                                                 boolean isExistedReview , List<GiftResponseDto> giftList) {

--- a/src/main/java/efub/gift_u/domain/notice/dto/AllNoticeDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/AllNoticeDto.java
@@ -6,21 +6,30 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AllNoticeDto {
 
-    private LocalDate date;
-    private List<FundingNoticeDto> funding;
-    private List<FriendNoticeDto> friend;
+    private LocalDateTime now;
+    private List<FundingDueNoticeDto> fundingDueDate;
+    private List<FundingAchieveDto> fundingAchieve;
+    private List<FriendNoticeDto> friendNotice;
 
-    public static AllNoticeDto from(LocalDate today, List<FundingNoticeDto> fundingNoticeDto, List<FriendNoticeDto> friendNoticeDtos){
+    public AllNoticeDto(LocalDateTime now , List<FundingDueNoticeDto> fundingDueNoticeDtos , List<FundingAchieveDto> fundingAchieveDtos ,List<FriendNoticeDto> friend){
+        this.now = now;
+        this.fundingDueDate = fundingDueNoticeDtos;
+        this.fundingAchieve = fundingAchieveDtos;
+        this.friendNotice = friend;
+    }
+
+    public static AllNoticeDto from(LocalDateTime now ,List<FundingDueNoticeDto> fundingDueNoticeDto,List<FundingAchieveDto> fundingAchieveDtos, List<FriendNoticeDto> friendNoticeDtos){
          return new AllNoticeDto(
-                 today,
-                 fundingNoticeDto,
+                 now,
+                 fundingDueNoticeDto,
+                 fundingAchieveDtos,
                  friendNoticeDtos
          );
     }

--- a/src/main/java/efub/gift_u/domain/notice/dto/FriendNoticeDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FriendNoticeDto.java
@@ -2,6 +2,7 @@ package efub.gift_u.domain.notice.dto;
 
 import efub.gift_u.domain.friend.domain.Friend;
 import efub.gift_u.domain.friend.domain.FriendStatus;
+import efub.gift_u.domain.friend.dto.FriendDetailDto;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +11,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FriendNoticeDto {
 
@@ -19,6 +19,14 @@ public class FriendNoticeDto {
     private Long secondUserId;
     private FriendStatus status;
     private LocalDateTime updatedAt;
+
+    public FriendNoticeDto(Long friendTableId , Long firstUserId , Long secondUserId , FriendStatus status , LocalDateTime updatedAt){
+        this.friendTableId = friendTableId;
+        this.firstUserId = firstUserId;
+        this.secondUserId = secondUserId;
+        this.status = status;
+        this.updatedAt = updatedAt;
+    }
 
     public static FriendNoticeDto from(Friend friend) {
         return new FriendNoticeDto(

--- a/src/main/java/efub/gift_u/domain/notice/dto/FundingAchieveDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FundingAchieveDto.java
@@ -1,0 +1,30 @@
+package efub.gift_u.domain.notice.dto;
+
+import efub.gift_u.domain.funding.domain.Funding;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FundingAchieveDto {
+       Long fundingId;
+       String fundingTitle;
+       double percent;
+
+       public FundingAchieveDto(Long fundingId , String fundingTitle , double percent){
+           this.fundingId = fundingId;
+           this.fundingTitle = fundingTitle;
+           this.percent = percent;
+       }
+
+       public static FundingAchieveDto from (Funding funding , double percent){
+           return new FundingAchieveDto(
+                        funding.getFundingId(),
+                        funding.getFundingTitle(),
+                        percent
+                   );
+       }
+
+
+}

--- a/src/main/java/efub/gift_u/domain/notice/dto/FundingAllNoticeDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FundingAllNoticeDto.java
@@ -1,0 +1,38 @@
+package efub.gift_u.domain.notice.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FundingAllNoticeDto {
+
+    private LocalDateTime now;
+    private List<FundingDueNoticeDto> fundingDueDate;
+    private List<FundingAchieveDto> fundingAchieve;
+
+    public FundingAllNoticeDto(LocalDateTime now , List<FundingDueNoticeDto> fundingDueDate , List<FundingAchieveDto> fundingAchieve){
+        this.now = now;
+        this.fundingDueDate = fundingDueDate;
+        this.fundingAchieve = fundingAchieve;
+    }
+
+    public static FundingAllNoticeDto from(LocalDateTime now , List<FundingDueNoticeDto> fundingDueDate , List<FundingAchieveDto> fundingAchieve){
+        return new FundingAllNoticeDto(
+                now,
+                fundingDueDate,
+                fundingAchieve
+        );
+    }
+
+    //비었는지 확인
+    @JsonIgnore
+    public boolean isEmpty() {
+        return (fundingDueDate == null && fundingAchieve == null);
+    }
+}

--- a/src/main/java/efub/gift_u/domain/notice/dto/FundingDueNoticeDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FundingDueNoticeDto.java
@@ -3,16 +3,14 @@ package efub.gift_u.domain.notice.dto;
 import efub.gift_u.domain.funding.domain.Funding;
 import efub.gift_u.domain.funding.domain.FundingStatus;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FundingNoticeDto {
+public class FundingDueNoticeDto {
 
     private Long fundingId;
     private Long userId;
@@ -20,8 +18,16 @@ public class FundingNoticeDto {
     private LocalDate fundingEndDate;
     private FundingStatus status;
 
-    public static FundingNoticeDto from(Funding funding){
-        return new FundingNoticeDto(
+    public  FundingDueNoticeDto (Long fundingId , Long userId , String fundingTitle , LocalDate fundingEndDate , FundingStatus status ){
+        this.fundingId = fundingId;
+        this.userId = userId;
+        this.fundingTitle = fundingTitle;
+        this.fundingEndDate = fundingEndDate;
+        this.status = status;
+    }
+
+    public static FundingDueNoticeDto from(Funding funding){
+        return new FundingDueNoticeDto(
                 funding.getFundingId(),
                 funding.getUser().getUserId(),
                 funding.getFundingTitle(),

--- a/src/main/java/efub/gift_u/domain/notice/service/NoticeService.java
+++ b/src/main/java/efub/gift_u/domain/notice/service/NoticeService.java
@@ -4,11 +4,9 @@ import efub.gift_u.domain.friend.domain.Friend;
 import efub.gift_u.domain.friend.repository.FriendRepository;
 import efub.gift_u.domain.funding.domain.Funding;
 import efub.gift_u.domain.funding.repository.FundingRepository;
-import efub.gift_u.domain.notice.dto.AllNoticeDto;
-import efub.gift_u.domain.notice.dto.FriendNoticeDto;
-import efub.gift_u.domain.notice.dto.FundingNoticeDto;
+import efub.gift_u.domain.gift.domain.Gift;
+import efub.gift_u.domain.notice.dto.*;
 import efub.gift_u.domain.oauth.customAnnotation.AuthUser;
-import efub.gift_u.domain.participation.domain.Participation;
 import efub.gift_u.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,7 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Collections;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,6 +32,7 @@ public class NoticeService {
     private final FundingRepository fundingRepository;
 
     LocalDate today = LocalDate.now(); //오늘 날짜
+    LocalDateTime now = LocalDateTime.now();
     
 
     /* 친구 알림 조회 , (현재 요청 상태인 것만) 함수  */
@@ -59,8 +58,8 @@ public class NoticeService {
         return sortedNotices;
     }
 
-    /* 마감 임박 펀딩  조회 */
-    private List<FundingNoticeDto> fundingNotice(@AuthUser  User user) {
+    /* 마감 임박 펀딩 조회 */
+    private List<FundingDueNoticeDto> fundingDueNotice(@AuthUser  User user) {
 
         List<Funding> deadlineFundings=  fundingRepository.findAllByUserId(user.getUserId());
 
@@ -72,14 +71,34 @@ public class NoticeService {
                 })
                 .collect(Collectors.toList());
 
-        List<FundingNoticeDto> fundingNoticeDtos = filteredFunding.stream()
-                .map(funding -> FundingNoticeDto.from(funding))
+        List<FundingDueNoticeDto> fundingDueNoticeDtos = filteredFunding.stream()
+                .map(funding -> FundingDueNoticeDto.from(funding))
                 .collect(Collectors.toList());
 
-        return fundingNoticeDtos;
+        return fundingDueNoticeDtos;
     }
 
-    /* 친구 알림 함수 조회 */
+    /*펀딩 달성도 조회*/
+    private List<FundingAchieveDto> fundingAchieveNotice(@AuthUser User user){
+            // 사용자가 개설한 펀딩
+            List<Funding> allFunding = fundingRepository.findAllByUserId(user.getUserId());
+
+            // 해당 펀딩의 현재 모인 금액 / 해당 펀딩의 최고액 선물 값
+            List<FundingAchieveDto> fundingAchieveDtos = allFunding.stream()
+                    .map(funding -> {
+                                double maxGiftPrice = funding.getGiftList().stream()
+                                        .mapToDouble(Gift::getPrice)
+                                        .max()
+                                        .orElse(0.0);
+                                double percent = maxGiftPrice>0? (funding.getNowMoney()/maxGiftPrice)*100 : 0.0;
+                                return FundingAchieveDto.from(funding , percent);
+                            })
+                    .collect(Collectors.toList());
+
+            return fundingAchieveDtos;
+    }
+
+    /* 친구 알림 조회 함수 */
     public ResponseEntity<?> getFriendNotice(@AuthUser User user){
 
         List<FriendNoticeDto> friendNoticeDto = friendNotice(user);
@@ -94,25 +113,30 @@ public class NoticeService {
 
     /* 펀딩 알림 조회 */
     public ResponseEntity<?> getFundingNotice(@AuthUser  User user){
-        List<FundingNoticeDto> fundingNoticeDtos = fundingNotice(user);
-
-        if(fundingNoticeDtos.isEmpty()){
+        List<FundingDueNoticeDto> fundingDueNoticeDtos = fundingDueNotice(user);
+        List<FundingAchieveDto> fundingAchieveDtos = fundingAchieveNotice(user);
+        FundingAllNoticeDto fundingAllNotices = FundingAllNoticeDto.from(now , fundingDueNoticeDtos , fundingAchieveDtos);
+        
+        if(fundingAllNotices.isEmpty()){
             return ResponseEntity.status(HttpStatus.OK)
                     .body("펀딩 알림이 없습니다.");
         }
         return ResponseEntity.status(HttpStatus.OK)
-                .body(fundingNoticeDtos);
+                .body(fundingAllNotices);
     }
 
 
-    /* 펀딩 전체 알림 조회 */
+    /* 전체 알림 조회 */
     public ResponseEntity<?> getAllNotice(@AuthUser User user) {
-        // 펀딩 알림
-        List<FundingNoticeDto> fundingNoticeDtos = fundingNotice(user);
+        // 펀딩 알림 _ 펀딩 종료 관련
+        List<FundingDueNoticeDto> fundingDueNoticeDtos = fundingDueNotice(user);
+        //펀딩 알림 _ 펀딩 달성 퍼센트
+        List<FundingAchieveDto> fundingAchieveDtos = fundingAchieveNotice(user);
+
         // 친구 알림
         List<FriendNoticeDto> friendNoticeDto = friendNotice(user);
 
-        AllNoticeDto allNoticeDto = AllNoticeDto.from(today , fundingNoticeDtos , friendNoticeDto);
+        AllNoticeDto allNoticeDto = AllNoticeDto.from(now ,fundingDueNoticeDtos ,fundingAchieveDtos ,friendNoticeDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(allNoticeDto);

--- a/src/main/java/efub/gift_u/domain/participation/dto/JoinRequestDto.java
+++ b/src/main/java/efub/gift_u/domain/participation/dto/JoinRequestDto.java
@@ -7,20 +7,25 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JoinRequestDto {
 
 
     @NotNull(message = "기여금액은 필수입니다.")
-    private long contributionAmount;
+    private Long contributionAmount;
     // 익명성
     @NotNull(message = "익명성은 필수입니다.")
     private Boolean anonymity;
 
     private String message;
 
-    public static Participation toEntity(User user , Funding funding , long contributionAmount , Boolean anonymity , String message){
+    public  JoinRequestDto(Long contributionAmount, Boolean anonymity , String message){
+        this.contributionAmount = contributionAmount;
+        this.anonymity = anonymity;
+        this.message = message;
+    }
+
+    public static Participation toEntity(User user , Funding funding , Long contributionAmount , Boolean anonymity , String message){
         return Participation.builder()
                 .user(user)
                 .funding(funding)

--- a/src/main/java/efub/gift_u/domain/participation/dto/JoinResponseDto.java
+++ b/src/main/java/efub/gift_u/domain/participation/dto/JoinResponseDto.java
@@ -8,7 +8,6 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JoinResponseDto {
 
@@ -19,6 +18,17 @@ public class JoinResponseDto {
     private Boolean anonymous;
     private String message;
     private LocalDateTime created_at;
+
+    public JoinResponseDto(Long participationId , Long userId , Long fundingId , Long contributionAmount , Boolean anonymous , String message , LocalDateTime created_at){
+        this.participationId = participationId;
+        this.userId = userId;
+        this.fundingId = fundingId;
+        this.contributionAmount = contributionAmount;
+        this.anonymous = anonymous;
+        this.message = message;
+        this.created_at = created_at;
+    }
+
 
     public static JoinResponseDto from(Participation participation){
         return new JoinResponseDto(

--- a/src/main/java/efub/gift_u/domain/participation/dto/ParticipationResponseDto.java
+++ b/src/main/java/efub/gift_u/domain/participation/dto/ParticipationResponseDto.java
@@ -2,7 +2,7 @@ package efub.gift_u.domain.participation.dto;
 
 import efub.gift_u.domain.participation.domain.Participation;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,8 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ParticipationResponseDto {
 
 
@@ -23,6 +22,17 @@ public class ParticipationResponseDto {
      private LocalDateTime created_at;
      private Long contributionAmount;
      private String message;
+
+     public ParticipationResponseDto(Long participationId , String nickname , String  userImageUrl , Boolean anonymous ,
+                                     LocalDateTime created_at , Long contributionAmount , String message){
+         this.participationId = participationId;
+         this.nickname = nickname;
+         this.userImageUrl = userImageUrl;
+         this.anonymous = anonymous;
+         this.created_at = created_at;
+         this.contributionAmount = contributionAmount;
+         this.message = message;
+     }
 
      public static List<ParticipationResponseDto> from(List<Participation> participations){
 


### PR DESCRIPTION
## 변경 사항
- #27 
-  전체 알림 : 조회 시간 , 펀딩당 달성률 추가
-  펀딩 알림 : 조회 시간 , 펀딩당 달성률 추가
-  dto 클래스에서  `@AllArgsConstructor` 삭제 후 생성자 코드 추가
-  dto 클래스 자료형 변경

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
feat/pay -> development (브랜치 변경하는 걸 까먹었습니다,,,)

### ETC
왜 전체 알림 조회가 친구 알림 조회나 펀딩 알림 조회보다 api 응답 시간이 적게 걸리는지 모르겠다.
나중에 찾아볼 예정