### PR TITLE
refactor: 캘린더 - 마감일 펀딩 목록 조회 api 진행중인 펀딩만 조회되도록 수정

### DIFF
--- a/src/main/java/efub/gift_u/domain/funding/controller/FundingController.java
+++ b/src/main/java/efub/gift_u/domain/funding/controller/FundingController.java
@@ -72,10 +72,10 @@ public class FundingController {
     }
 
 
-    /* 마감일 펀딩 목록 조회 - 캘린더 */
+    /* 해당 마감일 진행중인 펀딩 목록 조회 - 캘린더 */
     @GetMapping("/calendar/{fundingEndDate}")
     public AllFundingResponseDto getFriendsFundingByUser(@AuthUser User user, @PathVariable("fundingEndDate")LocalDate fundingEndDate) {
-        return fundingService.getAllFriendsFundingByUserAndDate(user, fundingEndDate);
+        return fundingService.getAllInProgressFriendsFundingByUserAndDate(user, fundingEndDate);
     }
 
 

--- a/src/main/java/efub/gift_u/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/efub/gift_u/domain/funding/repository/FundingRepository.java
@@ -11,20 +11,20 @@ import java.util.List;
 
 public interface FundingRepository extends JpaRepository<Funding, Long> {
 
-
-
     @Query("SELECT f FROM Funding f WHERE f.user.userId = :userId ORDER BY f.createdAt DESC") // 최신순으로 정렬 (=개설일 역순)
     List<Funding> findAllByUserId(@Param("userId") Long userId);
 
     @Query("SELECT f FROM Funding f WHERE f.user.userId = :userId and f.status = :status ORDER BY f.createdAt DESC") // 최신순으로 정렬 (=개설일 역순)
     List<Funding> findAllByUserAndStatus(@Param("userId") Long userId, @Param("status") FundingStatus status);
 
-    @Query("SELECT f FROM Funding f WHERE f.user.userId = :userId and f.fundingEndDate = :fundingEndDate")
-    List<Funding> findAllByUserAndFundingEndDate(@Param("userId")Long userId, @Param("fundingEndDate") LocalDate fundingEndDate);
+    // 캘린더
+    @Query("SELECT f FROM Funding f WHERE f.user.userId = :userId AND f.fundingEndDate = :fundingEndDate AND (:status IS NULL OR f.status = :status)") // :status IS NULL인 경우 상태 조건 무시됨
+    List<Funding> findAllByUserAndFundingEndDateAndStatus(@Param("userId")Long userId, @Param("fundingEndDate") LocalDate fundingEndDate, @Param("status") FundingStatus status);
 
     // 검색
     @Query("SELECT f FROM Funding f where f.user.nickname LIKE %:searchWord% OR f.fundingTitle LIKE %:searchWord% OR f.fundingContent LIKE %:searchWord%")
     List<Funding> fundByUserOrFundingTitleOrFundingContent(@Param("searchWord") String searchWord);
 
     Funding findByFundingId(Long fundingId);
+
 }


### PR DESCRIPTION
## 변경 사항
- #10 
- 마감일 펀딩 목록 조회 api -진행중인 펀딩만 조회되도록 수정
- 캘린더 api 서비스 코드에서 중복되는 코드 메소드 추출

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/calendar-> development 

### 테스트 결과
<img width="673" alt="image" src="https://github.com/user-attachments/assets/444f088f-3dd9-40e6-8c6f-57ee3b8051f7">

![image](https://github.com/user-attachments/assets/334c07c6-41a1-4ee4-8faa-2517e732b7f1)

![image](https://github.com/user-attachments/assets/517f69e4-bbb4-49c9-b17b-4cd23d6fd750)