### PR TITLE
feat : 알림 정렬을 위한 펀딩 알림에서 해당 펀딩의 마지막 참여자의 펀딩 참여 시각을 응답 dto에 추가

### DIFF
--- a/src/main/java/efub/gift_u/domain/notice/dto/FundingAchieveDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FundingAchieveDto.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FundingAchieveDto {
@@ -12,20 +14,23 @@ public class FundingAchieveDto {
        String fundingTitle;
        String fundingImageUrl;
        double percent;
+       LocalDateTime lastParticipateTime;
 
-       public FundingAchieveDto(Long fundingId , String fundingTitle ,String fundingImageUrl, double percent){
+       public FundingAchieveDto(Long fundingId , String fundingTitle ,String fundingImageUrl, double percent , LocalDateTime lastParticipateTime){
            this.fundingId = fundingId;
            this.fundingTitle = fundingTitle;
            this.fundingImageUrl = fundingImageUrl;
            this.percent = percent;
+           this.lastParticipateTime = lastParticipateTime;
        }
 
-       public static FundingAchieveDto from (Funding funding , double percent){
+       public static FundingAchieveDto from (Funding funding , double percent , LocalDateTime lastParticipateTime){
            return new FundingAchieveDto(
                         funding.getFundingId(),
                         funding.getFundingTitle(),
                          funding.getFundingImageUrl(),
-                        percent
+                        percent,
+                   lastParticipateTime
                    );
        }
 

--- a/src/main/java/efub/gift_u/domain/notice/dto/FundingDueNoticeDto.java
+++ b/src/main/java/efub/gift_u/domain/notice/dto/FundingDueNoticeDto.java
@@ -33,7 +33,7 @@ public class FundingDueNoticeDto {
                 funding.getFundingId(),
                 funding.getUser().getUserId(),
                 funding.getFundingTitle(),
-                funding.getFundingImageUrl(), 
+                funding.getFundingImageUrl(),
                 funding.getFundingEndDate(),
                 funding.getStatus()
         );

--- a/src/main/java/efub/gift_u/domain/notice/service/NoticeService.java
+++ b/src/main/java/efub/gift_u/domain/notice/service/NoticeService.java
@@ -7,6 +7,7 @@ import efub.gift_u.domain.funding.repository.FundingRepository;
 import efub.gift_u.domain.gift.domain.Gift;
 import efub.gift_u.domain.notice.dto.*;
 import efub.gift_u.domain.oauth.customAnnotation.AuthUser;
+import efub.gift_u.domain.participation.repository.ParticipationRepository;
 import efub.gift_u.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ public class NoticeService {
 
     private final FriendRepository friendRepository;
     private final FundingRepository fundingRepository;
+    private final ParticipationRepository participationRepository;
 
     LocalDate today = LocalDate.now(); //오늘 날짜
     LocalDateTime now = LocalDateTime.now();
@@ -91,7 +93,9 @@ public class NoticeService {
                                         .max()
                                         .orElse(0.0);
                                 double percent = maxGiftPrice>0? (funding.getNowMoney()/maxGiftPrice)*100 : 0.0;
-                                return FundingAchieveDto.from(funding , percent);
+                                // 해당 펀딩의 마지막 참여자가 참여한 시간
+                        LocalDateTime lastParticipateTime = participationRepository.findCreatedAtByUserIdAndFundingId(user.getUserId(), funding.getFundingId()).get(0).getCreatedAt();
+                                return FundingAchieveDto.from(funding , percent , lastParticipateTime);
                             })
                     .collect(Collectors.toList());
 

--- a/src/main/java/efub/gift_u/domain/participation/repository/ParticipationRepository.java
+++ b/src/main/java/efub/gift_u/domain/participation/repository/ParticipationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,5 +30,8 @@ public interface ParticipationRepository extends  JpaRepository<Participation, L
 
     @Query("SELECT p FROM Participation p WHERE p.user.userId =:userId AND p.funding.fundingId =:fundingId")
     Optional<Participation> findByUserIdAndFundingId(@Param("userId") Long userId , @Param("fundingId") Long fundingId);
+
+    @Query("select p FROM Participation p where p.user.userId =:userId and p.funding.fundingId =:fundingId ORDER BY  p.createdAt DESC")
+    List<Participation> findCreatedAtByUserIdAndFundingId(@Param("userId") Long userId , @Param("fundingId") Long fundingId);
 
 }


### PR DESCRIPTION
## 변경 사항
- #27 
- 프론트에서 알림 정렬을 위한 펀딩 마지막 참여자의 참여 시각 추가
- 펀딩 달성률이 기준치를 넘으면 알림을 보내게 해야하는데 현재 알림 테이블이 따로 없으므로 펀딩의 마지막 참여시각을 추가함으로써 펀딩 정렬 기준 보완

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/notice-> development 
![image](https://github.com/user-attachments/assets/2271d9fe-fe87-4f63-b238-b644a56d95ec)
