### PR TITLE
fix: 친구 요청 중복되면 에러 처리

### DIFF
--- a/src/main/java/efub/gift_u/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/efub/gift_u/domain/friend/repository/FriendRepository.java
@@ -14,6 +14,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Optional<Friend> findByFirstUserAndSecondUser(User firstUser, User secondUser);
     List<Friend> findAllByFirstUserAndStatus(User firstUser, FriendStatus status);
     List<Friend> findAllBySecondUserAndStatus(User secondUser, FriendStatus status);
+    Optional<Friend> findByFirstUserAndSecondUserAndStatusIn(User firstUser, User secondUser, List<FriendStatus> statuses);
 
     @Query("SELECT p.user FROM Participation p JOIN Friend f ON (p.user.userId = f.secondUser.userId OR p.user.userId = f.firstUser.userId) " +
             "WHERE (f.firstUser.userId = :userId OR f.secondUser.userId = :userId) AND f.status = 'ACCEPTED' " +

--- a/src/main/java/efub/gift_u/domain/friend/service/FriendService.java
+++ b/src/main/java/efub/gift_u/domain/friend/service/FriendService.java
@@ -33,6 +33,12 @@ public class FriendService {
         User firstUser = currentUser.getUserId() < friend.getUserId() ? currentUser : friend;
         User secondUser = currentUser.getUserId() > friend.getUserId() ? currentUser : friend;
 
+        // 친구 요청 중복 확인
+        List<FriendStatus> pendingStatuses = List.of(FriendStatus.PENDING_FIRST_SECOND, FriendStatus.PENDING_SECOND_FIRST, FriendStatus.ACCEPTED);
+        if (friendRepository.findByFirstUserAndSecondUserAndStatusIn(firstUser, secondUser, pendingStatuses).isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATE_FRIEND_REQUEST);
+        }
+
         FriendStatus status = (firstUser.equals(currentUser)) ? FriendStatus.PENDING_FIRST_SECOND : FriendStatus.PENDING_SECOND_FIRST;
 
         Friend friendRequest = Friend.builder()

--- a/src/main/java/efub/gift_u/global/exception/ErrorCode.java
+++ b/src/main/java/efub/gift_u/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // Friend
     SELF_FRIEND_REQUEST_NOT_ALLOWED(HttpStatus.FORBIDDEN, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 요청을 찾을 수 없습니다."),
+    DUPLICATE_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "이미 친구 요청을 보냈습니다."),
     ACCEPT_AFTER_REJECT(HttpStatus.BAD_REQUEST, "이미 거절된 요청입니다."),
     REJECT_AFTER_ACCEPT(HttpStatus.BAD_REQUEST, "이미 수락된 요청입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원이 존재하지 않습니다."),


### PR DESCRIPTION
- FriendStatus가 PENDING_FIRST_SECOND, PENDING_SECOND_FIRST, ACCEPTED인 경우일 때 친구 요청을 할 경우 "이미 친구 요청을 보냈습니다." 에러 처리