### PR TITLE
fix : 결제 취소 기능 오류 부분 해결

### DIFF
--- a/src/main/java/efub/gift_u/domain/funding/controller/FundingController.java
+++ b/src/main/java/efub/gift_u/domain/funding/controller/FundingController.java
@@ -92,9 +92,8 @@ public class FundingController {
 
     //펀딩 삭제
     @DeleteMapping("/{fundingId}")
-    public ResponseEntity<String> deleteFunding(@AuthUser User user, @PathVariable Long fundingId){
-        fundingService.deleteFunding(fundingId, user);
-        return ResponseEntity.ok("펀딩이 성공적으로 삭제되었습니다.");
+    public ResponseEntity<?> deleteFunding(@AuthUser User user, @PathVariable Long fundingId){
+        return fundingService.deleteFunding(fundingId, user);
     }
 
     /* 주어진 기간 내 날짜별 마감 펀딩 존재 유무 조회 - 캘린더 */

--- a/src/main/java/efub/gift_u/domain/participation/controller/ParticipationController.java
+++ b/src/main/java/efub/gift_u/domain/participation/controller/ParticipationController.java
@@ -31,9 +31,8 @@ public class ParticipationController {
 
     /* 펀딩 참여 취소 */
     @DeleteMapping("/participation/{participationId}")
-    public ResponseEntity<String> cancelFundingParticipation(@AuthUser User user, @PathVariable("participationId") Long participationId) {
-        participationService.cancelFundingParticipation(user, participationId);
-        return ResponseEntity.ok("펀딩 참여가 성공적으로 취소되었습니다.");
+    public ResponseEntity<?> cancelFundingParticipation(@AuthUser User user, @PathVariable("participationId") Long participationId) {
+        return participationService.cancelFundingParticipation(user, participationId);
     }
 
     /*펀딩 익명성 변경 및 축하 메세지 변경 */

--- a/src/main/java/efub/gift_u/domain/pay/controller/PayController.java
+++ b/src/main/java/efub/gift_u/domain/pay/controller/PayController.java
@@ -61,15 +61,7 @@ public class PayController {
         }
         catch (CustomException e){
             log.info("펀딩 참여 결제 취소 : 펀딩 참여 결제 번호 {}" ,  payNumber);
-            boolean res = payService.cancelPayment(payNumber);
-            if(res){
-                return ResponseEntity.status(HttpStatus.OK)
-                        .body("결제 취소가 완료되었습니다.");
-            }
-            else{
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                        .body("결제 취소를 실패하였습니다.");
-            }
+           return payService.cancelPayment(payNumber);
 //            String token = refundService.getToken();
 //            refundService.refundRequest(token , payNumber , e.getMessage());
 //            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -83,15 +75,16 @@ public class PayController {
         log.info("펀딩 결제 취소 : 펀딩 참여 결제 번호 : {}" , imp_uid );
 //        String token = refundService.getToken();
 //        refundService.refundRequest(token , imp_uid , "결제 취소");
-        boolean res = payService.cancelPayment(imp_uid);
-        if(res){
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body("결제 취소가 완료되었습니다.");
-        }
-        else{
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("결제 취소를 실패하였습니다.");
-        }
+//          boolean res = payService.cancelPayment(imp_uid);
+//        if(res){
+//            return ResponseEntity.status(HttpStatus.OK)
+//                    .body("결제 취소가 완료되었습니다.");
+//        }
+//        else{
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+//                    .body("결제 취소를 실패하였습니다.");
+//        }
+        return payService.cancelPayment(imp_uid);
     }
 
 }

--- a/src/main/java/efub/gift_u/domain/pay/repository/PayRepository.java
+++ b/src/main/java/efub/gift_u/domain/pay/repository/PayRepository.java
@@ -11,6 +11,9 @@ public interface PayRepository extends JpaRepository<Pay, String> {
 
     long countByPayIdContainingIgnoreCase(String payId);
 
+    @Query("SELECT p FROM Pay p where p.payId =:payId")
+    Pay findByPayId(@Param("payId") String payId);
+
     @Query("SELECT p.payId FROM Pay p where p.funding.fundingId =:fundingId AND  p.user.userId =:userId")
     String findByFundingIdAndUserId(@Param("fundingId") Long fundingId ,@Param("userId") Long userId);
 

--- a/src/main/java/efub/gift_u/global/exception/ErrorCode.java
+++ b/src/main/java/efub/gift_u/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     DUPLICATED_IMP(HttpStatus.BAD_REQUEST , "결제 번호가 중복됩니다."),
     INVALID_AMOUNT(HttpStatus.BAD_REQUEST , "결제 금액이 일치하지 않습니다."),
     PAYMENT_NOT_FOUND(HttpStatus.BAD_REQUEST , "해당하는 결제 내역을 찾을 수 없습니다."),
+    NOT_FOUND_IN_PORTONE(HttpStatus.BAD_REQUEST , "포트원에서 해당하는 결제 내역을 찾을 수 없습니다."),
 
     // User
     USER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND, "해당 email를 가진 User를 찾을 수 없습니다.");


### PR DESCRIPTION
- #5 
- #82 
- 결제 취소시 포트원에서 해당 결제 고유 번호로 결제되는 결제건이 없을 경우 따로 응답 반환
- 기존에는 결제 취소 결과를 boolean에서 ResponseEntity로 바꿨음

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/pay -> development

### ETC
- ResponseEntity는 controller단에서 사용하는 걸 권장한다고 함 <- 수정 예정
- custom exception이 PayService에서 제대로 실행되지 않음 .... 더 찾아보겠음

