### PR TITLE
선물 사진 url, 선물 url, 회원 url db 필드 사이즈 증가

### DIFF
--- a/src/main/java/efub/gift_u/domain/gift/domain/Gift.java
+++ b/src/main/java/efub/gift_u/domain/gift/domain/Gift.java
@@ -26,10 +26,10 @@ public class Gift {
     @Column(nullable = false)
     private Long price;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1024)
     private String giftUrl;
 
-    @Column(nullable = false, length = 512)
+    @Column(nullable = false, length = 1024)
     private String giftImageUrl;
 
     @Builder

--- a/src/main/java/efub/gift_u/domain/user/domain/User.java
+++ b/src/main/java/efub/gift_u/domain/user/domain/User.java
@@ -34,7 +34,7 @@ public class User {
     @Column
     private Date birthday;
 
-    @Column(length = 512)
+    @Column(length = 1024)
     private String userImageUrl;
 
     @Column


### PR DESCRIPTION
파일 이름이 길어 사진이 올라가지 않는 문제가 발생하여 giftImageUrl, giftUrl, UserImageUrl의 필드 사이즈를 512에서 1024로 증가시킴